### PR TITLE
Added properties maxStackSize and numCrafted to DoorDescriptor

### DIFF
--- a/source/net/malisis/doors/door/DoorDescriptor.java
+++ b/source/net/malisis/doors/door/DoorDescriptor.java
@@ -65,9 +65,11 @@ public class DoorDescriptor
 
 	//item
 	private CreativeTabs tab;
+	private int maxStackSize = 1;
 
 	//recipe
 	private Object[] recipe;
+	private int numCrafted = 1;
 
 	public DoorDescriptor()
 	{
@@ -227,6 +229,22 @@ public class DoorDescriptor
 		this.recipe = recipe;
 	}
 
+	public int getNumCrafted() {
+		return numCrafted;
+	}
+
+	public void setNumCrafted(int numCrafted) {
+		this.numCrafted = numCrafted;
+	}
+
+	public int getMaxStackSize() {
+		return maxStackSize;
+	}
+
+	public void setMaxStackSize(int maxStackSize) {
+		this.maxStackSize = maxStackSize;
+	}
+
 	//#end Getters/Setters
 
 	public void readNBT(NBTTagCompound nbt)
@@ -290,7 +308,7 @@ public class DoorDescriptor
 		GameRegistry.registerBlock(block, block.getUnlocalizedName().substring(5));
 		GameRegistry.registerItem(item, item.getUnlocalizedName());
 		if (recipe != null)
-			GameRegistry.addRecipe(new ItemStack(item), recipe);
+			GameRegistry.addRecipe(new ItemStack(item, numCrafted), recipe);
 
 		return this;
 	}

--- a/source/net/malisis/doors/door/item/DoorItem.java
+++ b/source/net/malisis/doors/door/item/DoorItem.java
@@ -46,7 +46,7 @@ public class DoorItem extends ItemDoor
 		super(desc.getMaterial());
 
 		this.descriptor = desc;
-
+		this.maxStackSize = desc.getMaxStackSize();
 		setUnlocalizedName(desc.getName());
 		setTextureName(desc.getTextureName());
 		setCreativeTab(desc.getTab());


### PR DESCRIPTION
New try at making a pull request. 
Had to make a branch for the 1.7.10-1.4.3 commit to be able to clone that. Hopefully this should not include those commits that makes the code not compile.
"maxStackSize" to be able to make doors that stack. Defaults to 1 so it is compatible with previous version.
"numCrafted" to be able to have the recipe make multiple doors. Defaults to 1 so it is compatible with previous version.