### PR TITLE
Fixing incompatibility between immersive engineering drills and malisisdoors.

### DIFF
--- a/src/main/java/net/malisis/doors/block/Door.java
+++ b/src/main/java/net/malisis/doors/block/Door.java
@@ -310,8 +310,12 @@ public class Door extends BlockDoor implements IBoundingBox, IComponentProvider,
 	@Override
 	public void getDrops(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
 	{
+		ItemStack door = getDoorItemStack(world,pos);
+		if (door == null) {
+			return;
+		}
 		if (!isTop(state))
-			drops.add(getDoorItemStack(world, pos));
+			drops.add(door);
 	}
 
 	@Override


### PR DESCRIPTION
https://pastebin.com/j0XRnDvs

If you look at this pastebin, because immersive engineering drills mine both the bottom and top block (a guess), it causes it to have null drops. This then means that when it is put in the NonNullList, it triggers the validate NonNull, and then crashes the entire server.

I believe this fix should work, but will need testing. This is my first pull request, so if I've done anything wrong, feel free to tell me.